### PR TITLE
Ensure this.apiKey is defined before attempting to build API request.

### DIFF
--- a/app/services/EtherscanService.ts
+++ b/app/services/EtherscanService.ts
@@ -49,6 +49,10 @@ export class EtherscanService {
    * Build Etherscan API URL with parameters
    */
   private buildUrl(params: Record<string, string>, chainId: string = '1'): string {
+    if (!this.apiKey) {
+      throw new Error('Etherscan API key is not configured');
+    }
+
     const urlParams = new URLSearchParams({
       chainid: chainId,
       apikey: this.apiKey,


### PR DESCRIPTION
Ensure this.apiKey is defined before attempting to build API request. Fixes TypeScript issue: this.apiKey is of type string | undefined, but the URLSearchParams constructor expects all values to be strings.